### PR TITLE
Add additional required gems to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,9 @@ You can also drill down to only certain parts of your codebase like:
 
 Add this line to your application's Gemfile:
 
+    gem 'peek'
     gem 'peek-rblineprof'
+    gem 'rblineprof', github: 'tmm1/rblineprof' 
 
 And then execute:
 


### PR DESCRIPTION
The rblineprof requirement may go away soon as referenced in the README here: 
https://github.com/kainosnoema/rack-lineprof
