### PR TITLE
added support for Rouge syntax highlighting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.gem
 *.rbc
+*.swp
 .bundle
 .config
 .yardoc

--- a/lib/peek/rblineprof/controller_helpers.rb
+++ b/lib/peek/rblineprof/controller_helpers.rb
@@ -11,9 +11,9 @@ module Peek
 
       protected
 
-      def pygmentize(file_name, code, lexer = false)
+      def highlight(file_name, code, lexer = false)
         if lexer
-          SyntaxHighlighter.pygmentize(code, lexer_for_filename(file_name))
+          SyntaxHighlighter.highlight(code, lexer_for_filename(file_name))
         else
           code
         end
@@ -112,7 +112,7 @@ module Peek
               end
             end
             output << "<pre class='duration'>#{times.join("\n")}</pre>"
-            output << "<div class='code'>#{pygmentize(file_name, code.join, true)}</div>"
+            output << "<div class='code'>#{highlight(file_name, code.join, true)}</div>"
             output << "</div></div>" # .data then .peek-rblineprof-file
           end
 

--- a/lib/peek/rblineprof/controller_helpers.rb
+++ b/lib/peek/rblineprof/controller_helpers.rb
@@ -1,8 +1,4 @@
-begin
-  require 'pygments.rb'
-rescue LoadError
-  # Doesn't have pygments.rb installed
-end
+require 'peek/rblineprof/syntax_highlighter'
 
 module Peek
   module Rblineprof
@@ -15,13 +11,9 @@ module Peek
 
       protected
 
-      def pygmentize?
-        defined?(Pygments)
-      end
-
-      def pygmentize(file_name, code, lexer = nil)
-        if pygmentize? && lexer.present?
-          Pygments.highlight(code, :lexer => lexer_for_filename(file_name))
+      def pygmentize(file_name, code, lexer = false)
+        if lexer
+          SyntaxHighlighter.pygmentize(code, lexer_for_filename(file_name))
         else
           code
         end
@@ -33,8 +25,8 @@ module Peek
 
       def lexer_for_filename(file_name)
         case file_name
-        when /\.rb$/ then 'ruby'
-        when /\.erb$/ then 'erb'
+        when /\.rb$/  then :ruby
+        when /\.erb$/ then :erb
         end
       end
 
@@ -120,7 +112,7 @@ module Peek
               end
             end
             output << "<pre class='duration'>#{times.join("\n")}</pre>"
-            output << "<div class='code'>#{pygmentize(file_name, code.join, 'ruby')}</div>"
+            output << "<div class='code'>#{pygmentize(file_name, code.join, true)}</div>"
             output << "</div></div>" # .data then .peek-rblineprof-file
           end
 

--- a/lib/peek/rblineprof/highlighters/pygments_highlighter.rb
+++ b/lib/peek/rblineprof/highlighters/pygments_highlighter.rb
@@ -1,0 +1,9 @@
+module Peek
+  module Rblineprof
+    class PygmentsHighlighter
+      def self.process(code, lexer)
+        Pygments.highlight(code, :lexer => lexer)
+      end
+    end
+  end
+end

--- a/lib/peek/rblineprof/highlighters/rouge_highlighter.rb
+++ b/lib/peek/rblineprof/highlighters/rouge_highlighter.rb
@@ -10,13 +10,13 @@ module Peek
         formatter.format(lexer.new.lex(code))
       end
 
-      def find_lexer(lexer)
+      def self.find_lexer(lexer)
         lexers = {
-          :ruby => Rouge::Lexers::Ruby,
-          :erb  => Rouge::Lexers::ERB
+          ruby: Rouge::Lexers::Ruby,
+          erb:  Rouge::Lexers::ERB
         }
 
-        lexers.fetch(lexers.to_sym, :no_lexer)
+        lexers.fetch(lexer.to_sym, :no_lexer)
       end
     end
   end

--- a/lib/peek/rblineprof/highlighters/rouge_highlighter.rb
+++ b/lib/peek/rblineprof/highlighters/rouge_highlighter.rb
@@ -2,15 +2,21 @@ module Peek
   module Rblineprof
     class RougeHighlighter
       def self.process(code, lexer)
+        lexer = find_lexer(lexer)
+
+        return code if lexer == :no_lexer
+
+        formatter = Rouge::Formatters::HTML.new(:line_numbers => true)
+        formatter.format(lexer.new.lex(code))
+      end
+
+      def find_lexer(lexer)
         lexers = {
           :ruby => Rouge::Lexers::Ruby,
           :erb  => Rouge::Lexers::ERB
         }
 
-        formatter = Rouge::Formatters::HTML.new(:line_numbers => true)
-        lexer     = lexers[lexer.to_sym].new
-
-        formatter.format(lexer.lex(code))
+        lexers.fetch(lexers.to_sym, :no_lexer)
       end
     end
   end

--- a/lib/peek/rblineprof/highlighters/rouge_highlighter.rb
+++ b/lib/peek/rblineprof/highlighters/rouge_highlighter.rb
@@ -1,0 +1,17 @@
+module Peek
+  module Rblineprof
+    class RougeHighlighter
+      def self.process(code, lexer)
+        lexers = {
+          :ruby => Rouge::Lexers::Ruby,
+          :erb  => Rouge::Lexers::ERB
+        }
+
+        formatter = Rouge::Formatters::HTML.new(:line_numbers => true)
+        lexer     = lexers[lexer.to_sym].new
+
+        formatter.format(lexer.lex(code))
+      end
+    end
+  end
+end

--- a/lib/peek/rblineprof/syntax_highlighter.rb
+++ b/lib/peek/rblineprof/syntax_highlighter.rb
@@ -4,30 +4,34 @@ require 'peek/rblineprof/highlighters/rouge_highlighter.rb'
 module Peek
   module Rblineprof
     class SyntaxHighlighter
+      class_attribute :highlighter
+
       def self.highlight(code, lexer)
         return code unless highlighter
 
         highlighter.process(code, lexer)
       end
+    end
+  end
+end
 
-      private
+module Peek
+  module Rblineprof
+    begin
+      require 'pygments.rb'
 
-      def self.highlighter
-        @highlighter ||= -> {
-          begin
-            require 'pygments.rb'
-            return PygmentsHighlither
-          rescue LoadError
-            # Doesn't have pygments.rb installed
-          end
+      SyntaxHighlighter.highlighter = PygmentsHighlighter
+    rescue LoadError
+      # Doesn't have pygments.rb installed
+    end
 
-          begin
-            require 'rouge'
-            return RougeHighlighter
-          rescue LoadError
-            # Doesn't have rouge installed
-          end
-        }.call
+    if SyntaxHighlighter.highlighter.nil?
+      begin
+        require 'rouge'
+
+        SyntaxHighlighter.highlighter = RougeHighlighter
+      rescue LoadError
+        # Doesn't have rouge installed
       end
     end
   end

--- a/lib/peek/rblineprof/syntax_highlighter.rb
+++ b/lib/peek/rblineprof/syntax_highlighter.rb
@@ -4,7 +4,7 @@ require 'peek/rblineprof/highlighters/rouge_highlighter.rb'
 module Peek
   module Rblineprof
     class SyntaxHighlighter
-      def self.pygmentize(code, lexer)
+      def self.highlight(code, lexer)
         return code unless highlighter
 
         highlighter.process(code, lexer)

--- a/lib/peek/rblineprof/syntax_highlighter.rb
+++ b/lib/peek/rblineprof/syntax_highlighter.rb
@@ -1,5 +1,5 @@
-require 'peek/rblineprof/highlighters/pygments_highlighter.rb'
-require 'peek/rblineprof/highlighters/rouge_highlighter.rb'
+require 'peek/rblineprof/highlighters/pygments_highlighter'
+require 'peek/rblineprof/highlighters/rouge_highlighter'
 
 module Peek
   module Rblineprof

--- a/lib/peek/rblineprof/syntax_highlighter.rb
+++ b/lib/peek/rblineprof/syntax_highlighter.rb
@@ -1,0 +1,34 @@
+require 'peek/rblineprof/highlighters/pygments_highlighter.rb'
+require 'peek/rblineprof/highlighters/rouge_highlighter.rb'
+
+module Peek
+  module Rblineprof
+    class SyntaxHighlighter
+      def self.pygmentize(code, lexer)
+        return code unless highlighter
+
+        highlighter.process(code, lexer)
+      end
+
+      private
+
+      def self.highlighter
+        @highlighter ||= -> {
+          begin
+            require 'pygments.rb'
+            return PygmentsHighlither
+          rescue LoadError
+            # Doesn't have pygments.rb installed
+          end
+
+          begin
+            require 'rouge'
+            return RougeHighlighter
+          rescue LoadError
+            # Doesn't have rouge installed
+          end
+        }.call
+      end
+    end
+  end
+end


### PR DESCRIPTION
I use [Rouge](https://github.com/jayferd/rouge) in my Rails app so instead of installing Python and the pygments gem I forked the lib and added support for Rouge.

It also makes the `controller_helpers.rb` file a bit cleaner. 

Btw. I don't see any tests/specs ?
