### PR TITLE
Add note explaining what params to add to URL to use Peek

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ CoffeeScript:
 #= require peek/views/rblineprof
 ```
 
+To profile a page request, add `peek=true` and `lineprofiler=true` to the URL of your request. 
+
 ## Integration with pygments.rb
 
 By default peek-rblineprof renders the code of each file in plain text with no


### PR DESCRIPTION
I never used Peek before when I stumbled upon peek-rblineprof so I was unaware of the need for adding the peek and lineprofiler params. If that were in the documentation it would have saved an hour or so of me chasing down the issue and wasting the maintainer's time with a GitHub issue, so I figure it's worth adding to the README!
