### PR TITLE
Links should include query parameters

### DIFF
--- a/app/views/peek/views/_rblineprof.html.erb
+++ b/app/views/peek/views/_rblineprof.html.erb
@@ -1,10 +1,10 @@
 <%= link_to 'Profile', :lineprofiler => true %>
 <div class="peek-dropdown">
   <ul>
-    <li><%= link_to 'app', :lineprofiler => 'app' %></li>
-    <li><%= link_to 'views', :lineprofiler => 'views' %></li>
-    <li><%= link_to 'gems', :lineprofiler => 'gems' %></li>
-    <li><%= link_to 'all', :lineprofiler => 'all' %></li>
-    <li><%= link_to 'stdlib', :lineprofiler => 'stdlib' %></li>
+    <li><%= link_to 'app', params.merge(:lineprofiler => 'app') %></li>
+    <li><%= link_to 'views', params.merge(:lineprofiler => 'views') %></li>
+    <li><%= link_to 'gems', params.merge(:lineprofiler => 'gems') %></li>
+    <li><%= link_to 'all', params.merge(:lineprofiler => 'all') %></li>
+    <li><%= link_to 'stdlib', params.merge(:lineprofiler => 'stdlib') %></li>
   </ul>
 </div>


### PR DESCRIPTION
Links to profiler should not remove query parameters, since not everyone use pretty url
