### PR TITLE
Require peek in rblineprof

### DIFF
--- a/lib/peek-rblineprof.rb
+++ b/lib/peek-rblineprof.rb
@@ -1,3 +1,4 @@
+require 'peek'
 require 'peek/views/rblineprof'
 require 'peek-rblineprof/version'
 require 'peek-rblineprof/railtie'


### PR DESCRIPTION
This PR is to fix about https://github.com/peek/peek-rblineprof/issues/8 .
Now, **peek-rblineprof** cannot be added to Gemfile only itself.
Gemfiles need **peek**.

Because, `peek` must be required before `peek-rblineprof` will be loaded.
