### PR TITLE
Use around_action instead of around_filter

### DIFF
--- a/lib/peek/rblineprof/controller_helpers.rb
+++ b/lib/peek/rblineprof/controller_helpers.rb
@@ -12,7 +12,7 @@ module Peek
       extend ActiveSupport::Concern
 
       included do
-        around_filter :inject_rblineprof, :if => [:peek_enabled?, :rblineprof_enabled?]
+        around_action :inject_rblineprof, :if => [:peek_enabled?, :rblineprof_enabled?]
       end
 
       protected


### PR DESCRIPTION
around_filter is deprecated and will be removed in Rails 5.1.
Use around_action instead.