### PR TITLE
Use <pre> instead of <div> for the code element and add the 'highlight' class

### DIFF
--- a/lib/peek/rblineprof/controller_helpers.rb
+++ b/lib/peek/rblineprof/controller_helpers.rb
@@ -122,7 +122,7 @@ module Peek
               end
             end
             output << "<pre class='duration'>#{times.join("\n")}</pre>"
-            output << "<div class='code'>#{pygmentize(file_name, code.join, 'ruby')}</div>"
+            output << "<pre class='code highlight'>#{pygmentize(file_name, code.join, 'ruby')}</pre>"
             output << "</div></div>" # .data then .peek-rblineprof-file
           end
 


### PR DESCRIPTION
I think `<pre>` is better semantically for displaying code.

Also, by adding the highlight class, we allow the element to be styled for highlighting (possibly in JS).