### PR TITLE
Add modal toggler and respect current url params when profiling

### DIFF
--- a/app/assets/javascripts/peek/views/rblineprof.js
+++ b/app/assets/javascripts/peek/views/rblineprof.js
@@ -3,3 +3,14 @@ $(document).on('click', '.js-lineprof-file', function(e) {
   e.preventDefault();
   return false;
 });
+
+$(document).on('click', '.js-lineprof-modal-toggle', function(e) {
+  const toggle = e.target;
+  $('.peek-rblineprof-modal').toggle();
+
+  if (toggle.textContent === 'hide') {
+    toggle.textContent = 'show';
+  } else {
+    toggle.textContent = 'hide';
+  }
+});

--- a/app/assets/stylesheets/peek/views/rblineprof.scss
+++ b/app/assets/stylesheets/peek/views/rblineprof.scss
@@ -72,3 +72,7 @@
     }
   }
 }
+
+.lineprof-modal-toggle {
+  cursor: pointer;
+}

--- a/app/views/peek/views/_rblineprof.html.erb
+++ b/app/views/peek/views/_rblineprof.html.erb
@@ -5,10 +5,10 @@
 
 <div class="peek-dropdown">
   <ul>
-    <li><%= link_to 'app', url_for(:lineprofiler => 'app') %></li>
-    <li><%= link_to 'views', url_for(:lineprofiler => 'views') %></li>
-    <li><%= link_to 'gems', url_for(:lineprofiler => 'gems') %></li>
-    <li><%= link_to 'all', url_for(:lineprofiler => 'all') %></li>
-    <li><%= link_to 'stdlib', url_for(:lineprofiler => 'stdlib') %></li>
+    <li><%= link_to 'app', url_for(params.permit!.merge(:lineprofiler => 'app')) %></li>
+    <li><%= link_to 'views', url_for(params.permit!.merge(:lineprofiler => 'views')) %></li>
+    <li><%= link_to 'gems', url_for(params.permit!.merge(:lineprofiler => 'gems')) %></li>
+    <li><%= link_to 'all', url_for(params.permit!.merge(:lineprofiler => 'all')) %></li>
+    <li><%= link_to 'stdlib', url_for(params.permit!.merge(:lineprofiler => 'stdlib')) %></li>
   </ul>
 </div>

--- a/app/views/peek/views/_rblineprof.html.erb
+++ b/app/views/peek/views/_rblineprof.html.erb
@@ -1,4 +1,8 @@
 <%= link_to 'Profile', :lineprofiler => true %>
+<% if params[:lineprofiler] %>
+  <span class="lineprof-modal-toggle js-lineprof-modal-toggle">hide</span>
+<% end %>
+
 <div class="peek-dropdown">
   <ul>
     <li><%= link_to 'app', url_for(:lineprofiler => 'app') %></li>

--- a/lib/peek/rblineprof/controller_helpers.rb
+++ b/lib/peek/rblineprof/controller_helpers.rb
@@ -25,7 +25,7 @@ module Peek
         if pygmentize? && lexer.present?
           Pygments.highlight(code, :lexer => lexer_for_filename(file_name))
         else
-          "<pre>#{Rack::Utils.escape_html(code)}</pre>"
+          Rack::Utils.escape_html(code)
         end
       end
 


### PR DESCRIPTION
Hi there,

thanks for this wonderful gem

this pull requests adds 2 features to it

1) respects current page's url params. Until now page params were discarder(they were ignored when generating url with with `:lineprofiler => true`
2) adds simple modal toggler. When profiling is active, it adds hide/show toggler next to profiler link in Peek menu. This solves #10 

happy to update the patch if you don't like something, just let me know

Masa331

